### PR TITLE
Fix mistake in make_amova_table

### DIFF
--- a/PramCurry/R/allFunctions.R
+++ b/PramCurry/R/allFunctions.R
@@ -1086,7 +1086,7 @@ make_amova_table <- function(am, amt){
   res <- data.frame(list(am$results[-tot, c("Df", "Sum Sq")], 
                          Percent = am$componentsofcovariance[-tot, 2],
                          Pval    = rev(amt$pvalue), 
-                         Phi     = am$statphi$Phi[-tot]))
+                         Phi     = rev(am$statphi$Phi[-tot])))
   res <- as.matrix(res)
   colnames(res) <- c("d.f.", "Sum of Squares", "Percent variation", "P", 
                      "Phi statistic")


### PR DESCRIPTION
There was a mistake in the PramCurry function `make_amova_table()`
where the Phi values were presented in the reverse order. This means
that the results for the AMOVA table should look like this:

```
---------------------------------------------------------------------------------------------------
Heirarchy                          df Sum of squares Variation (%)           *P*   $\phi$ statistic 
-------------------------- ---------- -------------- ------------- ------------- ------------------
**Region by year**                                                                                  

Between region                  6 (6)       197 (23)     45 (12.3) 1e-04 (1e-04)       0.45 (0.123) 

Between year within region    16 (16)    22.5 (17.2) 4.56 (-0.283) 1e-04 (0.446)  0.0829 (-0.00323) 

Within year within region   490 (129)      281 (141)     50.4 (88) 1e-04 (1e-04)       0.496 (0.12) 

**Year by region**                                                                                  

Between year                  10 (10)       160 (21)      11.6 (3) 0.366 (0.175)       0.116 (0.03) 

Between region within year    12 (12)    59.5 (19.1)   33.3 (7.07) 1e-04 (2e-04)     0.376 (0.0729) 

Within region within year   490 (129)      281 (141)   55.2 (89.9) 1e-04 (1e-04)      0.448 (0.101) 

---------------------------------------------------------------------------------------------------
```